### PR TITLE
Integrate yamllint for local error diagnosis

### DIFF
--- a/.github/workflows/enforce_conventional_commits.yml
+++ b/.github/workflows/enforce_conventional_commits.yml
@@ -18,8 +18,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with: {fetch-depth: 0}
+        with: { fetch-depth: 0 }
 
       - name: Check Commit Messages
         uses: wagoid/commitlint-github-action@v6
-        with: {configFile: .commitlintrc.yml}
+        with: { configFile: .commitlintrc.yml }

--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -1,3 +1,4 @@
+---
 default: true
 
 # Unordered list indentation
@@ -10,10 +11,10 @@ MD013: { line_length: 90, tables: false, code_blocks: false }
 MD024: { siblings_only: true }
 
 # Do not allow the specified trailing punctuation in a header
-MD026: { punctuation: '.,;:' }
+MD026: { punctuation: ".,;:" }
 
 # Order list items must have a prefix that increases in numerical order
-MD029: { style: 'ordered' }
+MD029: { style: "ordered" }
 
 # Lists do not need to be surrounded by blank lines
 MD032: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,4 @@
+---
 inherit_gem:
   main_branch_shared_rubocop_config: config/rubocop.yml
 
@@ -12,6 +13,6 @@ Metrics/AbcSize:
     - "spec/**/*_spec.rb"
 
 AllCops:
-  # Pin this project to Ruby 3.1 in case the shared config above is upgraded to 3.2
-  # or later.
+  # Pin this project to Ruby 3.1 in case the shared config above is
+  # upgraded to 3.2 or later.
   TargetRubyVersion: 3.1

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,0 +1,12 @@
+---
+extends: default
+
+ignore: |
+  node_modules
+
+rules:
+  braces:
+    min-spaces-inside: 1
+    max-spaces-inside: 1
+  truthy:
+    check-keys: false


### PR DESCRIPTION
Integrate yamllint to enable local diagnosis of errors reported on qlty.sh, improving the development workflow.