### PR TITLE
Remove Rubocop plugin from QLTY build configuration

### DIFF
--- a/.qlty/qlty.toml
+++ b/.qlty/qlty.toml
@@ -84,11 +84,11 @@ name = "radarlint-ruby"
 name = "ripgrep"
 mode = "comment"
 
-[[plugin]]
-name = "rubocop"
-version = "1.75.2"
-package_file = "Gemfile"
-package_filters = ["rubocop"]
+# [[plugin]]
+# name = "rubocop"
+# version = "1.75.2"
+# package_file = "Gemfile"
+# package_filters = ["rubocop"]
 
 [[plugin]]
 name = "trivy"


### PR DESCRIPTION
Eliminate the Rubocop plugin from the build configuration to streamline dependencies.