### PR TITLE
Remove radarlint-ruby from quality checks

### DIFF
--- a/.qlty/qlty.toml
+++ b/.qlty/qlty.toml
@@ -77,8 +77,8 @@ mode = "comment"
 [[plugin]]
 name = "prettier"
 
-[[plugin]]
-name = "radarlint-ruby"
+# [[plugin]]
+# name = "radarlint-ruby"
 
 [[plugin]]
 name = "ripgrep"


### PR DESCRIPTION
Eliminate false positives for duplication by removing the radarlint-ruby plugin from the quality checks configuration.