### PR TITLE
Release v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,19 @@
 # Change Log
+
+## v0.1.0 (2025-04-08)
+
+[Full Changelog](https://github.com/main-branch/track_open_instances/compare/f0fb459..v0.1.0)
+
+Changes:
+
+- f2d5318 chore: remove radarline-ruby from qlty checks
+- 177eba8 chore: fix formatting errors reported by `qlty fmt`
+- 943359f build: remove rubocop plugin from qlty
+- 476f271 chore: integrate yamllint
+- 56811ca fix: add qlty configuration in order to run qlty checks locally
+- e83546a fix: fix continuous integration workflow issues reported by qlty.sh
+- 6f67aed test: add predicate methods to determine the Ruby engine and platform
+- 34e3829 build: generate JSON coverage report for qlty.sh coverage reporting
+- 9db2052 docs: update README links
+- 937a971 build: update code coverage reporting
+- f0fb459 feat: initial implementation of TrackOpenInstances


### PR DESCRIPTION
# Release PR

## v0.1.0 (2025-04-08)

[Full Changelog](https://github.com/main-branch/track_open_instances/compare/f0fb459..v0.1.0)

Changes:

* f2d5318 chore: remove radarline-ruby from qlty checks
* 177eba8 chore: fix formatting errors reported by `qlty fmt`
* 943359f build: remove rubocop plugin from qlty
* 476f271 chore: integrate yamllint
* 56811ca fix: add qlty configuration in order to run qlty checks locally
* e83546a fix: fix continuous integration workflow issues reported by qlty.sh
* 6f67aed test: add predicate methods to determine the Ruby engine and platform
* 34e3829 build: generate JSON coverage report for qlty.sh coverage reporting
* 9db2052 docs: update README links
* 937a971 build: update code coverage reporting
* f0fb459 feat: initial implementation of TrackOpenInstances
