### PR TITLE
build: remove the prettier plugin from qlty lint check

### DIFF
--- a/.qlty/qlty.toml
+++ b/.qlty/qlty.toml
@@ -74,8 +74,8 @@ name = "markdownlint"
 version = "0.41.0"
 mode = "comment"
 
-[[plugin]]
-name = "prettier"
+# [[plugin]]
+# name = "prettier"
 
 # [[plugin]]
 # name = "radarlint-ruby"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 ### Bug Fixes
 
-- Fix several documentation and report errors ([fd17199](https://github.com/main-branch/track_open_instances/commit/fd171997871796df746c8e1312a4fdb07cb363d5))
-- Start autoreleases at 0.1.0 ([5a2fad7](https://github.com/main-branch/track_open_instances/commit/5a2fad7a9cb029a5dbfb9785f979fc07bf7f127b))
+* Fix several documentation and report errors ([fd17199](https://github.com/main-branch/track_open_instances/commit/fd171997871796df746c8e1312a4fdb07cb363d5))
+* Start autoreleases at 0.1.0 ([5a2fad7](https://github.com/main-branch/track_open_instances/commit/5a2fad7a9cb029a5dbfb9785f979fc07bf7f127b))
 
 ## v0.1.0 (2025-04-08)
 
@@ -13,14 +13,14 @@
 
 Changes:
 
-- f2d5318 chore: remove radarline-ruby from qlty checks
-- 177eba8 chore: fix formatting errors reported by `qlty fmt`
-- 943359f build: remove rubocop plugin from qlty
-- 476f271 chore: integrate yamllint
-- 56811ca fix: add qlty configuration in order to run qlty checks locally
-- e83546a fix: fix continuous integration workflow issues reported by qlty.sh
-- 6f67aed test: add predicate methods to determine the Ruby engine and platform
-- 34e3829 build: generate JSON coverage report for qlty.sh coverage reporting
-- 9db2052 docs: update README links
-- 937a971 build: update code coverage reporting
-- f0fb459 feat: initial implementation of TrackOpenInstances
+* f2d5318 chore: remove radarline-ruby from qlty checks
+* 177eba8 chore: fix formatting errors reported by `qlty fmt`
+* 943359f build: remove rubocop plugin from qlty
+* 476f271 chore: integrate yamllint
+* 56811ca fix: add qlty configuration in order to run qlty checks locally
+* e83546a fix: fix continuous integration workflow issues reported by qlty.sh
+* 6f67aed test: add predicate methods to determine the Ruby engine and platform
+* 34e3829 build: generate JSON coverage report for qlty.sh coverage reporting
+* 9db2052 docs: update README links
+* 937a971 build: update code coverage reporting
+* f0fb459 feat: initial implementation of TrackOpenInstances


### PR DESCRIPTION
The release-please github action lists each change in the change log starting with a '-'. 

However, the `qlty check` command raises an error that fails the build because it expectes unordered lists to be prefixed with '*'. This is because it uses prettier under the hood which can not be configured to use any other bullet character. 