### PR TITLE
Remove incorrect releasing instructions from documentation

### DIFF
--- a/.yardopts
+++ b/.yardopts
@@ -5,5 +5,4 @@
 --readme README.md
 - CHANGELOG.md
 - CONTRIBUTING.md
-- RELEASING.md
 - LICENSE.txt

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,9 +1,0 @@
-# How to release a new track_open_instances gem
-
-Run `create-github-release <release-type>` in the root of a clean working tree.
-
-Where `release-type` is `major`, `minor`, or `patch` depending on the nature of the
-changes. Refer to the labels on each PR since the last release to determine which
-semver release type to specify.
-
-Follow the directions that `create-github-release` after it prepares the release PR.


### PR DESCRIPTION
Eliminate outdated and incorrect instructions for releasing the track_open_instances gem.

This gem will be released automatically when a PR is merged to the main branch using the release-please GitHub Action.