### PR TITLE
Update Gemfile instruction for clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ to aid debugging.
 
 ## Installation
 
-Add this line to your application's Gemfile:
+Add this line to your application's or gem's Gemfile:
 
 ```Ruby
 gem 'track_open_instances'


### PR DESCRIPTION
Clarify the Gemfile instruction to specify that it applies to both applications and gems.