### PR TITLE
Automatically push the new gem releases to rubygems.org

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,12 @@
 ---
-name: Release
+name: Release Gem
+description: |
+  This workflow creates a new release on GitHub and publishes the gem to
+  RubyGems.org.
+
+  The workflow uses the `googleapis/release-please-action` to handle the
+  release creation process and the `rubygems/release-gem` action to publish
+  the gem.
 
 on:
   push:
@@ -7,17 +14,35 @@ on:
 
   workflow_dispatch:
 
-permissions:
-  contents: write
-  pull-requests: write
-
 jobs:
   release:
     runs-on: ubuntu-latest
+
+    environment:
+      name: RubyGems
+      url: https://rubygems.org/gems/track_open_instances
+
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write
+
     steps:
-      - uses: googleapis/release-please-action@v4
+      - name: Define Release
+        uses: googleapis/release-please-action@v4
         id: release
         with:
           token: ${{ secrets.AUTO_RELEASE_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        if: ${{ steps.release.outputs.release_created }}
+        with:
+          bundler-cache: true
+          ruby-version: ruby
+
+      - name: Push to RubyGems.org
+        uses: rubygems/release-gem@v1
+        if: ${{ steps.release.outputs.release_created }}


### PR DESCRIPTION
Use the rubygems/release-gem action to publish the track_open_instances to rubygems.org.