### PR TITLE
Fix release workflow to checkout project

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,9 @@ jobs:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 
+      - name: Checkout project
+        uses: actions/checkout@v4
+
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         if: ${{ steps.release.outputs.release_created }}


### PR DESCRIPTION
Ensure the release workflow includes a step to checkout the project before proceeding with the setup.