### PR TITLE
Fix release workflow by checking out the project first

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,9 @@ jobs:
       id-token: write
 
     steps:
+      - name: Checkout Project
+        uses: actions/checkout@v4
+
       - name: Define Release
         uses: googleapis/release-please-action@v4
         id: release
@@ -35,9 +38,6 @@ jobs:
           token: ${{ secrets.AUTO_RELEASE_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
-
-      - name: Checkout project
-        uses: actions/checkout@v4
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1


### PR DESCRIPTION
Ensure the project is checked out before the release-please step in the release workflow to allow proper version number updates in the version.rb file.