### PR TITLE
Change release-please tag for feature branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,10 +28,10 @@ jobs:
       id-token: write
 
     steps:
-      - name: Checkout Project
+      - name: Checkout project
         uses: actions/checkout@v4
 
-      - name: Create Release
+      - name: Create release
         uses: googleapis/release-please-action@v4
         id: release
         with:
@@ -39,7 +39,7 @@ jobs:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 
-      - name: Setup Ruby
+      - name: Setup ruby
         uses: ruby/setup-ruby@v1
         if: ${{ steps.release.outputs.release_created }}
         with:

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,14 +2,13 @@
   "bootstrap-sha": "c0076bab53d3eae31f3798217e281e3d51a292a3",
   "packages": {
     ".": {
-      "changelog-path": "CHANGELOG.md",
       "release-type": "ruby",
+      "changelog-path": "CHANGELOG.md",
       "version-file": "lib/track_open_instances/version.rb",
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
       "draft": false,
-      "prerelease": false,
-      "include-component-in-tag": false
+      "prerelease": false
     }
   },
   "plugins": [


### PR DESCRIPTION
Update the release-please configuration to use a different tag than release-gem for feature branches, ensuring consistency in tagging and release management. Minor adjustments made to the workflow steps for clarity.