### PR TITLE
Add package-name to release-please configuration

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,6 +3,7 @@
   "packages": {
     ".": {
       "release-type": "ruby",
+      "package-name": "track_open_instances",
       "changelog-path": "CHANGELOG.md",
       "version-file": "lib/track_open_instances/version.rb",
       "bump-minor-pre-major": true,


### PR DESCRIPTION
Add the `package-name` field to the release-please configuration to ensure that tags created by release-please do not conflict with those generated by the `rake release` task.