### PR TITLE
Remove component name from release version tag

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -17,6 +17,13 @@ Bundler::Audit::Task.new
 require 'bundler'
 require 'bundler/gem_tasks'
 
+# Make it so that calling `rake release` just calls `rake release:rubygems_push` to
+# avoid creating and pushing a new tag.
+
+# Rake::Task['release'].clear
+# desc 'Customized release task to avoid creating a new tag'
+# task release: 'release:rubygems_push'
+
 # RSpec
 
 require 'rspec/core/rake_task'

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -9,7 +9,8 @@
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
       "draft": false,
-      "prerelease": false
+      "prerelease": false,
+      "include-component-in-tag": false
     }
   },
   "plugins": [


### PR DESCRIPTION
Eliminate the inclusion of the component name in the release version tag and adjust the release task to prevent creating and pushing a new tag.