### PR TITLE
Fix release task to prevent tag creation

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -20,9 +20,9 @@ require 'bundler/gem_tasks'
 # Make it so that calling `rake release` just calls `rake release:rubygems_push` to
 # avoid creating and pushing a new tag.
 
-# Rake::Task['release'].clear
-# desc 'Customized release task to avoid creating a new tag'
-# task release: 'release:rubygems_push'
+Rake::Task['release'].clear
+desc 'Customized release task to avoid creating a new tag'
+task release: 'release:rubygems_push'
 
 # RSpec
 


### PR DESCRIPTION
Amend the release task to avoid creating a new tag, as the release-please GitHub action already handles tag creation. This change prevents build failures related to tag overwriting.