### PR TITLE
Fix release task to prevent tag creation

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -22,7 +22,7 @@ require 'bundler/gem_tasks'
 
 Rake::Task['release'].clear
 desc 'Customized release task to avoid creating a new tag'
-task release: 'release:rubygems_push'
+task release: 'release:rubygem_push'
 
 # RSpec
 


### PR DESCRIPTION
Amend the release task to avoid creating a new tag, as the release-please GitHub action already handles tag creation. This change prevents build failures caused by overwriting existing tags.