### PR TITLE
Update release pull request title format

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -10,7 +10,8 @@
       "bump-patch-for-minor-pre-major": true,
       "draft": false,
       "prerelease": false,
-      "include-component-in-tag": false
+      "include-component-in-tag": false,
+      "group-pull-request-title-pattern": "Release v${branch}"
     }
   },
   "plugins": [


### PR DESCRIPTION
Enhance the user-friendliness of release pull request titles by implementing a new format: "Release v0.1.2".