### PR TITLE
Optimize CI builds for supported Ruby versions

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -13,19 +13,6 @@ on:
 
   workflow_dispatch:
 
-env:
-  # SimpleCov suggests setting the JRuby --debug flag to ensure that coverage
-  # results from JRuby are complete.
-  JRUBY_OPTS: --debug
-  GIT_AUTHOR_NAME: Git Author
-  GIT_AUTHOR_EMAIL: git_author@example.com
-  GIT_COMMITTER_NAME: Git Committer
-  GIT_COMMITTER_EMAIL: git_committer@example.com
-
-# Supported platforms / Ruby versions:
-#  - Ubuntu: MRI (3.1, 3.2, 3.3, 3.4), TruffleRuby (24), JRuby (9.4)
-#  - Windows: MRI (3.1)
-
 jobs:
   build:
     name: Ruby ${{ matrix.ruby }} on ${{ matrix.operating-system }}
@@ -39,7 +26,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.1", "3.2", "3.3", "3.4"]
+        # Build on the minimal and maximal Ruby versions supported
+        ruby: ["3.1", "3.4"]
         operating-system: [ubuntu-latest]
         fail_on_low_coverage: ["true"]
 

--- a/.github/workflows/experimental_ruby_builds.yml
+++ b/.github/workflows/experimental_ruby_builds.yml
@@ -10,15 +10,6 @@ on:
 
   workflow_dispatch:
 
-env:
-  # SimpleCov suggests setting the JRuby --debug flag to ensure that coverage
-  # results from JRuby are complete.
-  JRUBY_OPTS: --debug
-
-# Experimental platforms / Ruby versions:
-#  - Ubuntu: MRI (head), TruffleRuby (head), JRuby (head)
-#  - Windows: MRI (head), JRuby (head), JRuby (9.4)
-
 jobs:
   build:
     name: Ruby ${{ matrix.ruby }} on ${{ matrix.operating-system }}
@@ -28,30 +19,13 @@ jobs:
 
     env:
       FAIL_ON_LOW_COVERAGE: ${{ matrix.fail_on_low_coverage }}
-      GIT_AUTHOR_NAME: Git Author
-      GIT_AUTHOR_EMAIL: git_author@example.com
-      GIT_COMMITTER_NAME: Git Committer
-      GIT_COMMITTER_EMAIL: git_committer@example.com
 
     strategy:
       fail-fast: false
       matrix:
+        ruby: ["head"]
+        operating-system: [ubuntu-latest]
         fail_on_low_coverage: ["true"]
-        include:
-          - ruby: head
-            operating-system: ubuntu-latest
-          - ruby: "jruby-9.4"
-            operating-system: ubuntu-latest
-            fail_on_low_coverage: "false"
-          - ruby: "truffleruby-24"
-            operating-system: ubuntu-latest
-            fail_on_low_coverage: "false"
-          - ruby: head
-            operating-system: windows-latest
-            fail_on_low_coverage: "false"
-          - ruby: 3.1
-            operating-system: windows-latest
-            fail_on_low_coverage: "false"
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Remove builds on Windows and for the TruffleRuby and JRuby engines. The differences in these platforms and engines do not warrent a separate CI build for them.

Also, only build on the minimal (3.1) and maximal (3.4) versions of Ruby. Assume that building with inbetween versions won't make much of a difference.

This should greatly speed up CI builds.

Also remove some cruft that had been copied from other projects.