### PR TITLE
Remove pull request title pattern from release configuration

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -10,8 +10,7 @@
       "bump-patch-for-minor-pre-major": true,
       "draft": false,
       "prerelease": false,
-      "include-component-in-tag": false,
-      "pull-request-title-pattern": "Release ${branch}"
+      "include-component-in-tag": false
     }
   },
   "plugins": [


### PR DESCRIPTION
Adjust the release configuration to ensure the pull request title pattern only affects the PR title, preventing failures in the project's release workflow.