### PR TITLE
Prevent CI builds on merges to main

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -5,9 +5,6 @@ permissions:
   contents: read
 
 on:
-  push:
-    branches: [main]
-
   pull_request:
     branches: [main]
 

--- a/.github/workflows/experimental_ruby_builds.yml
+++ b/.github/workflows/experimental_ruby_builds.yml
@@ -5,9 +5,6 @@ permissions:
   contents: read
 
 on:
-  push:
-    branches: [main]
-
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Adjust the CI workflows to avoid triggering builds when merging to the main branch, ensuring builds run only for pull requests targeting main and allowing manual triggering for experimental builds.